### PR TITLE
Add Quick Setup preset to SerializedStateMachine editor (one-click Player states)

### DIFF
--- a/Assets/_Project/Scripts/Editor.meta
+++ b/Assets/_Project/Scripts/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8d91e05951524cb8b1d7f077be27b935
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/Editor/SerializedStateMachineEditor.cs
+++ b/Assets/_Project/Scripts/Editor/SerializedStateMachineEditor.cs
@@ -1,0 +1,210 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using UnityPatterns.FiniteStateMachine;
+
+[CustomEditor(typeof(SerializedStateMachine))]
+public class SerializedStateMachineEditor : Editor
+{
+    private static readonly List<Type> StateTypes = TypeCache.GetTypesDerivedFrom<IState>()
+        .Where(t => !t.IsAbstract && !t.IsInterface && !t.ContainsGenericParameters)
+        .OrderBy(t => t.FullName)
+        .ToList();
+
+    private static readonly string[] PlayerDefaultStateTypeNames =
+    {
+        "PlayerStateDefault",
+        "PlayerStateBlocking",
+        "PlayerStateAttacking",
+        "PlayerStateComboing",
+        "PlayerStateComboEnding",
+        "PlayerStateDodging",
+        "PlayerStateJumping",
+        "PlayerStateStaggered",
+        "PlayerStateDead"
+    };
+
+    public override void OnInspectorGUI()
+    {
+        serializedObject.Update();
+
+        DrawScriptField();
+
+        SerializedProperty defaultState = serializedObject.FindProperty("defaultState");
+        SerializedProperty states = serializedObject.FindProperty("states");
+        SerializedProperty transitions = serializedObject.FindProperty("transitions");
+
+        EditorGUILayout.Space();
+        DrawManagedReferenceSelector(defaultState, "Default State", StateTypes);
+
+        EditorGUILayout.Space();
+        DrawStatesList(states);
+
+        EditorGUILayout.Space();
+        DrawPresetButtons(defaultState, states);
+
+        EditorGUILayout.Space();
+        EditorGUILayout.PropertyField(transitions, includeChildren: true);
+
+        serializedObject.ApplyModifiedProperties();
+    }
+
+    private void DrawScriptField()
+    {
+        using (new EditorGUI.DisabledScope(true))
+        {
+            MonoScript script = MonoScript.FromScriptableObject((ScriptableObject)target);
+            EditorGUILayout.ObjectField("Script", script, typeof(MonoScript), false);
+        }
+    }
+
+    private static void DrawPresetButtons(SerializedProperty defaultState, SerializedProperty states)
+    {
+        EditorGUILayout.LabelField("Quick Setup", EditorStyles.boldLabel);
+        using (new EditorGUI.IndentLevelScope())
+        {
+            if (GUILayout.Button("Populate Player Default States"))
+            {
+                ApplyStatePreset(defaultState, states, PlayerDefaultStateTypeNames, "PlayerStateDefault");
+            }
+
+            if (GUILayout.Button("Clear All States"))
+            {
+                defaultState.managedReferenceValue = null;
+                states.arraySize = 0;
+            }
+        }
+    }
+
+    private static void ApplyStatePreset(
+        SerializedProperty defaultState,
+        SerializedProperty states,
+        IReadOnlyList<string> stateTypeNames,
+        string defaultStateTypeName)
+    {
+        var presetTypes = stateTypeNames
+            .Select(FindStateTypeByName)
+            .Where(t => t != null)
+            .Distinct()
+            .ToList();
+
+        if (presetTypes.Count == 0)
+        {
+            Debug.LogWarning("SerializedStateMachineEditor: no matching state types were found for the preset.");
+            return;
+        }
+
+        states.arraySize = presetTypes.Count;
+        for (int i = 0; i < presetTypes.Count; i++)
+        {
+            states.GetArrayElementAtIndex(i).managedReferenceValue = Activator.CreateInstance(presetTypes[i]);
+        }
+
+        Type defaultType = FindStateTypeByName(defaultStateTypeName) ?? presetTypes[0];
+        defaultState.managedReferenceValue = Activator.CreateInstance(defaultType);
+    }
+
+    private static Type FindStateTypeByName(string typeName)
+    {
+        return StateTypes.FirstOrDefault(t => t.Name == typeName);
+    }
+
+    private void DrawStatesList(SerializedProperty states)
+    {
+        EditorGUILayout.LabelField("States", EditorStyles.boldLabel);
+
+        using (new EditorGUI.IndentLevelScope())
+        {
+            for (int i = 0; i < states.arraySize; i++)
+            {
+                SerializedProperty stateProp = states.GetArrayElementAtIndex(i);
+                EditorGUILayout.BeginVertical("box");
+                EditorGUILayout.BeginHorizontal();
+                DrawManagedReferenceSelector(stateProp, $"Element {i}", StateTypes);
+
+                if (GUILayout.Button("-", GUILayout.Width(24)))
+                {
+                    states.DeleteArrayElementAtIndex(i);
+                    EditorGUILayout.EndHorizontal();
+                    EditorGUILayout.EndVertical();
+                    break;
+                }
+
+                EditorGUILayout.EndHorizontal();
+                EditorGUILayout.EndVertical();
+            }
+
+            if (GUILayout.Button("+ Add State"))
+            {
+                states.InsertArrayElementAtIndex(states.arraySize);
+                SerializedProperty newState = states.GetArrayElementAtIndex(states.arraySize - 1);
+                newState.managedReferenceValue = CreateDefaultStateInstance();
+            }
+        }
+    }
+
+    private static object CreateDefaultStateInstance()
+    {
+        if (StateTypes.Count == 0)
+        {
+            return null;
+        }
+
+        return Activator.CreateInstance(StateTypes[0]);
+    }
+
+    private static void DrawManagedReferenceSelector(
+        SerializedProperty property,
+        string label,
+        IReadOnlyList<Type> candidateTypes)
+    {
+        EditorGUILayout.BeginVertical();
+
+        Type currentType = GetManagedReferenceType(property);
+        int currentIndex = currentType == null ? 0 : candidateTypes.IndexOf(currentType) + 1;
+
+        string[] options = new string[candidateTypes.Count + 1];
+        options[0] = "None";
+        for (int i = 0; i < candidateTypes.Count; i++)
+        {
+            options[i + 1] = candidateTypes[i].Name;
+        }
+
+        int newIndex = EditorGUILayout.Popup(label, currentIndex, options);
+        if (newIndex != currentIndex)
+        {
+            property.managedReferenceValue = newIndex == 0
+                ? null
+                : Activator.CreateInstance(candidateTypes[newIndex - 1]);
+        }
+
+        if (property.managedReferenceValue != null)
+        {
+            EditorGUILayout.PropertyField(property, GUIContent.none, includeChildren: true);
+        }
+
+        EditorGUILayout.EndVertical();
+    }
+
+    private static Type GetManagedReferenceType(SerializedProperty property)
+    {
+        if (property == null || string.IsNullOrEmpty(property.managedReferenceFullTypename))
+        {
+            return null;
+        }
+
+        string[] split = property.managedReferenceFullTypename.Split(' ');
+        if (split.Length != 2)
+        {
+            return null;
+        }
+
+        string assemblyName = split[0];
+        string typeName = split[1];
+        return Type.GetType($"{typeName}, {assemblyName}");
+    }
+}
+#endif

--- a/Assets/_Project/Scripts/Editor/SerializedStateMachineEditor.cs.meta
+++ b/Assets/_Project/Scripts/Editor/SerializedStateMachineEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98d068b9ade04f7d925b7bebb8df60cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/Gameplay/Player/PlayerState.cs
+++ b/Assets/_Project/Scripts/Gameplay/Player/PlayerState.cs
@@ -53,5 +53,6 @@ namespace BrightSouls.Gameplay
     public class PlayerStateAttacking : PlayerState { }
     public class PlayerStateComboing : PlayerState { }
     public class PlayerStateComboEnding : PlayerState { }
+    public class PlayerStateDefault : PlayerState { }
     public class PlayerStateJumping : PlayerState { }
 }

--- a/Assets/_Project/Scripts/Helpers/UnityPatterns/State/StateMachine.cs
+++ b/Assets/_Project/Scripts/Helpers/UnityPatterns/State/StateMachine.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 namespace UnityPatterns.FiniteStateMachine
 {
+    [CreateAssetMenu(fileName = "SerializedStateMachine", menuName = "BrightSouls/State/SerializedStateMachine", order = 0)]
     public sealed class SerializedStateMachine : ScriptableObject
     {
         /* ------------------------------- Properties ------------------------------- */

--- a/Assets/_Project/Scripts/Helpers/UnityPatterns/State/StateMachineController.cs
+++ b/Assets/_Project/Scripts/Helpers/UnityPatterns/State/StateMachineController.cs
@@ -47,7 +47,7 @@ namespace UnityPatterns.FiniteStateMachine
                 }
                 else
                 {
-                    Debug.LogError($"StateMachineController on \"{defaultName}\" has no default or configured states.");
+                    Debug.LogError($"StateMachineController on \"{defaultName}\" has no default or configured states. Add at least one state (for Player, e.g. PlayerStateDefault) to SerializedStateMachine.");
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- Setting up `SerializeReference`-backed FSM assets in the Inspector was tedious and error-prone, so provide a one-click baseline to populate common Player states and a default state.

### Description
- Added a `Quick Setup` section to the custom inspector in `Assets/_Project/Scripts/Editor/SerializedStateMachineEditor.cs` with `Populate Player Default States` and `Clear All States` buttons that instantiate and assign preset `IState` types into the `defaultState` and `states` serialized references.
- The preset uses a hard-coded list of player state type names and resolves them against the discovered non-abstract `IState` implementations, skipping any missing types and instantiating the found types into the array.
- Added a concrete `PlayerStateDefault` class in `Assets/_Project/Scripts/Gameplay/Player/PlayerState.cs` so the default player state is selectable/instantiable, and added a `CreateAssetMenu` attribute to `SerializedStateMachine` in `Assets/_Project/Scripts/Helpers/UnityPatterns/State/StateMachine.cs` to allow asset creation from the Unity menu.
- Improved startup diagnostics in `Assets/_Project/Scripts/Helpers/UnityPatterns/State/StateMachineController.cs` to mention adding at least one state (for example `PlayerStateDefault`), and included `.meta` files for the new editor assets.

### Testing
- Ran `git diff --check` to verify there were no whitespace/style issues (succeeded).
- Inspected the new editor file with `nl -ba` to confirm the quick-setup UI, preset list, and instantiation logic were added as intended (succeeded).
- Verified repository status and file presence with status checks to ensure the working tree contained the intended changes (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997273cbbe8832489e090336e5cc4f7)