### PR TITLE
Refine grounded detection and add action/combat logging to fix unreliable jumps

### DIFF
--- a/Assets/_Project/Scripts/Gameplay/Player/Combat/PlayerCombatCommands.cs
+++ b/Assets/_Project/Scripts/Gameplay/Player/Combat/PlayerCombatCommands.cs
@@ -43,8 +43,11 @@ namespace BrightSouls.Gameplay
             {
                 if (!CanExecute())
                 {
+                    Debug.Log("[PlayerCombat] Attack ignored: CanExecute=false.");
                     return;
                 }
+
+                Debug.Log($"[PlayerCombat] Attack executed. attackId={attackId}");
 
                 if (player.State != null && player.State.Fsm != null)
                 {
@@ -62,6 +65,7 @@ namespace BrightSouls.Gameplay
                     return;
                 }
 
+                Debug.Log("[PlayerCombat] No weapon found. Using fallback overlap attack.");
                 ApplyFallbackForwardAttackDamage();
             }
 


### PR DESCRIPTION
### Motivation
- Users reported jumps failing not just from timing but from unreliable grounded detection, so grounding logic needed hardening rather than only input-edge fixes. 
- Improve observability of movement/jump/attack flow so runtime diagnostics reveal why actions are accepted or rejected. 

### Description
- Reworked grounded evaluation in `PlayerMotor` into a new `EvaluateGroundedState()` that returns true if `CharacterController.isGrounded` is true, otherwise probes feet with `Physics.CheckSphere` and a short downward `Physics.SphereCast` using the serialized `groundedProbeOffset` and `groundedProbeRadiusScale` tuning fields. 
- Updated `UpdateGroundedState()` to use `EvaluateGroundedState()` and added logging for grounded-state transitions when `verboseActionLogging` is enabled. 
- Switched jump detection to frame-based input with `WasPressedThisFrame()` and removed the old edge-tracking field, plus added explicit jump-accepted / jump-rejected debug logs to make coyote/window failures visible. 
- Added lightweight runtime logs for attack flow in `PlayerCombatCommands` to indicate when an attack is ignored, executed, or falling back to the overlap attack. 
- Added `LogMoveInputIfChanged()` to emit simple move-start/move-stop messages when verbose logging is enabled. 

### Testing
- Ran `git diff --check` to ensure no whitespace/errors were introduced (succeeded). 
- Ran `git status --short` to confirm tracked changes and commit state (succeeded) and committed the change with a descriptive message. 
- Attempted Unity availability check with `which unity || which unity-editor` and detected no Editor in this environment, so PlayMode/Runtime validation must be performed inside the Unity Editor (not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c53bca088324ad9d6c087eb0d784)